### PR TITLE
Dream comment/username

### DIFF
--- a/frontend/src/util/dream_api_util.js
+++ b/frontend/src/util/dream_api_util.js
@@ -25,7 +25,7 @@ export const fetchDreamsByTags = tags => (
 )
 
 export const updateDream = (dreamId, updatedFields) => (
-  axios.post(`/api/dreams/update/${dreamId}`, updatedFields)
+  axios.patch(`/api/dreams/${dreamId}`, updatedFields)
 )
 
 export const deleteDream = dreamId => (

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -6,6 +6,10 @@ const CommentSchema = new Schema({
     type: Schema.Types.ObjectId,
     ref: 'users'
   },
+  username: {
+    type: String,
+    required: true
+  },
   dreamId: {
     type: Schema.Types.ObjectId,
     ref: 'dreams'

--- a/models/Dream.js
+++ b/models/Dream.js
@@ -6,6 +6,10 @@ const DreamSchema = new Schema({
     type: Schema.Types.ObjectId,
     ref: 'users'
   },
+  username: {
+    type: String,
+    required: true
+  },
   text: {
     type: String,
     required: true

--- a/routes/api/comments.js
+++ b/routes/api/comments.js
@@ -22,6 +22,7 @@ router.post('/:dreamId',
           .then(dream => {
             const newComment = new Comment({
               userId: req.user.id,
+              username: req.user.username,
               dreamId: req.params.dreamId,
               comment: req.body.comment
             })

--- a/routes/api/dreams.js
+++ b/routes/api/dreams.js
@@ -20,6 +20,7 @@ router.post('/',
 
         const newDream = new Dream({
             userId: req.user.id,
+            username: req.user.username,
             text: req.body.text,
             tags: req.body.tags,
             type: req.body.type


### PR DESCRIPTION
This pull request is to add the username to the Dream/Comment documents and did some cleaning up of the Dream CRUD

This is achieved by:
- Adding a username field to both the Dream and Comment models
- Including a username in the new Dream and Comment create POST requests (gotten via req.user.username)
- Updated the Dream update route to use PATCH instead of POST with a shorter route (removed a `/update/`)