### PR TITLE
Dream redux

### DIFF
--- a/frontend/src/actions/dream_actions.js
+++ b/frontend/src/actions/dream_actions.js
@@ -1,23 +1,17 @@
 import * as DreamApiUtils from '../util/dream_api_util';
 
-export const RECEIVE_ALL_DREAMS = 'RECEIVE_ALL_DREAMS';
-export const RECEIVE_USER_DREAMS = 'RECEIVE_USER_DREAMS';
-export const RECEIVE_NEW_DREAM = 'RECEIVE_NEW_DREAM';
+export const RECEIVE_DREAMS = 'RECEIVE_DREAMS';
+export const RECEIVE_DREAM = 'RECEIVE_DREAM';
 export const REMOVE_DREAMS = 'REMOVE_DREAMS';
+export const CLEAR_DREAMS = 'CLEAR_DREAMS';
 
-
-export const receiveAllDreams = (dreams) => ({
-    type: RECEIVE_ALL_DREAMS, 
+export const receiveDreams = (dreams) => ({
+    type: RECEIVE_DREAMS, 
     dreams
 });
 
-export const receiveUserDreams = (dreams) => ({
-    type: RECEIVE_USER_DREAMS,
-    dreams 
-});
-
-export const receiveNewDream = (dream) => ({
-    type: RECEIVE_NEW_DREAM,
+export const receiveDream = (dream) => ({
+    type: RECEIVE_DREAM,
     dream
 });
 
@@ -26,50 +20,53 @@ export const removeDreams = (dreamId) => ({
     dreamId
 })
 
+export const clearDreams = () => ({
+    type: CLEAR_DREAMS,
+})
 
 export const fetchDreams = () => dispatch => (
     DreamApiUtils.fetchDreams()
-    .then(dreams => dispatch(receiveAllDreams(dreams)))
+    .then(dreams => dispatch(receiveDreams(dreams.data)))
     .catch(err => console.log(err))
 )
 
 export const fetchDreamsByUser = userId => dispatch => (
     DreamApiUtils.fetchDreamsByUser(userId)
-    .then(dreams => dispatch(receiveUserDreams(dreams)))
+    .then(dreams => dispatch(receiveDreams(dreams.data)))
     .catch(err => console.error(err))
 )
 
 export const fetchDreamById = dreamId => dispatch => (
     DreamApiUtils.fetchDreamById(dreamId)
-    .then(dream => dispatch(receiveNewDream(dream)))
+    .then(dream => dispatch(receiveDream(dream.data)))
     .catch(err => console.error(err))
 )
 
 export const fetchDreamsByType = type => dispatch => (
     DreamApiUtils.fetchDreamsByType(type)
-    .then(dreams => dispatch(receiveAllDreams(dreams)))
+    .then(dreams => dispatch(receiveDreams(dreams.data)))
     .catch(err => console.error(err))
 )
 
 export const fetchDreamsByTags = tags => dispatch => (
     DreamApiUtils.fetchDreamsByTags(tags)
-    .then(dreams => dispatch(receiveAllDreams(dreams)))
+    .then(dreams => dispatch(receiveDreams(dreams.data)))
     .catch(err => console.error(err))
 )
 
 export const createDream = dream => dispatch => (
     DreamApiUtils.createDream(dream)
-    .then(dream => dispatch(receiveNewDream(dream)))
+    .then(dream => dispatch(receiveDream(dream.data)))
     .catch(err => console.error(err))
 )
 
 export const updateDream = (dreamId, updatedFields) => dispatch  => (
     DreamApiUtils.updateDream(dreamId, updatedFields)
-    .then((dreamId, updatedFields)=> dispatch(receiveNewDream(dreamId, updatedFields)))
+    .then((dreamId, updatedFields)=> dispatch(receiveDream(dreamId, updatedFields)))
     .catch(err => console.error(err))
 )
 
 export const deleteDream = dreamId => dispatch => (
     DreamApiUtils.deleteDream(dreamId)
-    .then(() => dispatch(removeDreams(dreamId)))
+    .then(dreamId => dispatch(removeDreams(dreamId)))
 )

--- a/frontend/src/actions/dream_actions.js
+++ b/frontend/src/actions/dream_actions.js
@@ -62,7 +62,7 @@ export const createDream = dream => dispatch => (
 
 export const updateDream = (dreamId, updatedFields) => dispatch  => (
     DreamApiUtils.updateDream(dreamId, updatedFields)
-    .then((dreamId, updatedFields)=> dispatch(receiveDream(dreamId, updatedFields)))
+    .then(dream => dispatch(receiveDream(dream)))
     .catch(err => console.error(err))
 )
 

--- a/frontend/src/reducers/dream_reducer.js
+++ b/frontend/src/reducers/dream_reducer.js
@@ -13,9 +13,9 @@ const DreamReducer = (oldState = {}, action) => {
             action.dreams.forEach(dream => {
                 newState[dream._id] = dream
             })
-            return action.dreams;
+            return newState;
         case RECEIVE_DREAM:
-            newState[action.dream.id] = action.dream; 
+            newState[action.dream._id] = action.dream; 
             return newState;
         case REMOVE_DREAMS:
             delete newState[action.dreamId]

--- a/frontend/src/reducers/dream_reducer.js
+++ b/frontend/src/reducers/dream_reducer.js
@@ -1,25 +1,27 @@
 import { 
-    RECEIVE_ALL_DREAMS,
-    RECEIVE_USER_DREAMS,
-    RECEIVE_NEW_DREAM,
-    REMOVE_DREAMS
+    RECEIVE_DREAMS,
+    RECEIVE_DREAM,
+    REMOVE_DREAMS,
+    CLEAR_DREAMS
 } from '../actions/dream_actions'
 
-const DreamReducer = (oldState = {all: {}, user: {}, new: undefined}, action) => {
+const DreamReducer = (oldState = {}, action) => {
     Object.freeze(oldState)
     let newState = Object.assign({}, oldState); 
     switch(action.type) {
-        case RECEIVE_ALL_DREAMS:
+        case RECEIVE_DREAMS:
+            action.dreams.forEach(dream => {
+                newState[dream._id] = dream
+            })
             return action.dreams;
-        case RECEIVE_USER_DREAMS:
-            newState[action.user.id] = action.user; 
-            return newState;
-        case RECEIVE_NEW_DREAM:
+        case RECEIVE_DREAM:
             newState[action.dream.id] = action.dream; 
             return newState;
         case REMOVE_DREAMS:
             delete newState[action.dreamId]
             return newState; 
+        case CLEAR_DREAMS:
+            return {};
         default: 
             return oldState; 
     }

--- a/routes/api/comments.js
+++ b/routes/api/comments.js
@@ -83,7 +83,7 @@ router.patch('/:commentId',
             if (err) {
               res.status(400).json(err);
             } else {
-              res.json(comment)
+              res.json(comment);
             }
           })
         }

--- a/routes/api/dreams.js
+++ b/routes/api/dreams.js
@@ -86,7 +86,10 @@ router.patch('/:dreamId',
             return res.json.status(400).json(errors);
         }
 
-        var query = { _id: req.params.dreamId }
+        var query = { _id: req.params.dreamId },
+            update = { $set: req.body },
+            options = { new: true }
+
         Dream.findOne(query)
             .then(dream => {
                 if (dream.userId != req.user.id) {
@@ -95,11 +98,11 @@ router.patch('/:dreamId',
                     if (req.body.text.length === 0) {
                         delete req.body.text;
                     }
-                    Dream.update(query, { $set: req.body }, function(err) {
+                    Dream.findOneAndUpdate(query, update, options, (err, dream) => {
                         if(err) {
                             res.status(400).json(err);
                         } else {
-                            res.json(req.params.dreamId);
+                            res.json(dream);
                         }
                     })
                 }

--- a/validation/create_dream.js
+++ b/validation/create_dream.js
@@ -15,7 +15,7 @@ module.exports = function validateCreateDreamInput(data) {
   }
 
   if (data.tags && data.tags.length > 3) {
-    errors.tags = 'Only 10 tags are allowed'
+    errors.tags = 'Only 3 tags are allowed'
   }
 
   if (!Validator.equals(data.type, 'dream') && !Validator.equals(data.type, 'goal')) {

--- a/validation/update_dream.js
+++ b/validation/update_dream.js
@@ -11,7 +11,7 @@ module.exports = function validateUpdateDreamInput(data) {
   }
 
   if (data.tags && data.tags.length > 10) {
-    errors.tags = 'Only 10 tags are allowed'
+    errors.tags = 'Only 3 tags are allowed'
   }
 
   if (data.type && !Validator.equals(data.type, 'dream') && !Validator.equals(data.type, 'goal')) {


### PR DESCRIPTION
This pull request encapsulates a refactoring of the dream redux cycle to simplify the corresponding slice of the state

This was accomplished by:
- Simplifying the non-thunk actions to just be receiveDream and receiveDreams
- Reducing state to just be an object with key being dreamId and value being the corresponding dream
- Modifying the update PATCH route in the backend to return the dream itself so that the store could also receive the update
- Adding a CLEAR_DREAMS action allowing for the  resetting of state following component unmounts