### PR TITLE
Fix bug where superuser wasn't able to delete comments

### DIFF
--- a/routes/api/comments.js
+++ b/routes/api/comments.js
@@ -120,7 +120,7 @@ router.delete('/:commentId',
     Comment.findOne({ _id: req.params.commentId })
       .then(comment => {
         
-        if (comment.userId != req.user.id) {
+        if (comment.userId != req.user.id && req.user.id != "6008ae5487226a3ee8c43414") {
           res.status(400)
             .json({ userauth: 'You can only delete your own comments'})
         } else {


### PR DESCRIPTION
This PR gives superuser the correct permissions to delete comments

This was done by:
1. Adding an additional condition to the backend route to prevent an auth error from being sent