### PR TITLE
Bugfix

### DIFF
--- a/frontend/src/util/route_util.js
+++ b/frontend/src/util/route_util.js
@@ -19,7 +19,7 @@ const Protected = ({ component: Component, loggedIn, ...rest }) => (
       loggedIn ? (
         <Component {...props} />
       ) : (
-        <Redirect to="/login" />
+        <Redirect to="/#/login" />
       )
     }
   />


### PR DESCRIPTION
This PR tries to resolve the cannot GET /login route error

This is done by:
- changing the redirect link to include the # for proper router parsing